### PR TITLE
Swapped recommendation for Crates extension to Dependi.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,8 @@
 {
   "recommendations": [
     "esbenp.prettier-vscode",
+    "fill-labs.dependi",
     "rust-lang.rust-analyzer",
-    "serayuzgur.crates",
     "streetsidesoftware.code-spell-checker",
     "tamasfe.even-better-toml"
   ]


### PR DESCRIPTION
The Creates extension is deprecated and recommends Dependi as a replacement.